### PR TITLE
Fix browser navigation keys

### DIFF
--- a/src/components/routers/GalleryRouter.tsx
+++ b/src/components/routers/GalleryRouter.tsx
@@ -1,12 +1,9 @@
-import { useNavigate } from "react-router-dom";
 import { Gallery } from "react-grid-gallery";
 import { useCallback, useState } from "react";
 import { Box, IconButton, Typography, Modal } from "@mui/material";
 import { PlayCircleOutlined } from '@mui/icons-material';
 
 export const GalleryRouter: React.FC = () => {
-    
-    const navigate = useNavigate()
 
     const [showModal, setShowModal] = useState<boolean>(false)
     const [imageIndex, setImageIndex] = useState<number>(0)
@@ -44,7 +41,7 @@ export const GalleryRouter: React.FC = () => {
     })
 
     const handleSessionLoad = useCallback(() => {
-        navigate(imageData[imageIndex].sessionUrl)
+        window.location.href = imageData[imageIndex].sessionUrl as string
     }, [imageIndex])
 
     const handleFigureClick = (currentIndex: number) => {


### PR DESCRIPTION
This update fixes the issue where the browser's navigation arrow keys would break the app when switching between gallery sessions. 