### PR TITLE
Fix nested routes and tutorial MTZ column names for diff maps

### DIFF
--- a/src/components/MoorhenApp.tsx
+++ b/src/components/MoorhenApp.tsx
@@ -48,14 +48,14 @@ export const MoorhenApp: React.FC = () => {
             },
             {
                 path: "gallery",
-                element: (
-                    <>
-                        <GalleryLayout />
-                        <Outlet/>
-                    </>
-                ),
+                element:  <Outlet />,
                 children: [
                     {
+                        path: "",
+                        element: <GalleryLayout />
+                    },
+                    {
+                        index: true,
                         path: ":galleryId",
                         element: <GallerySessionLayout />
                     }

--- a/src/components/MoorhenApp.tsx
+++ b/src/components/MoorhenApp.tsx
@@ -1,13 +1,13 @@
 
 import { ErrorBoundary, MoorhenReduxStore } from 'moorhen'
 import { Provider } from 'react-redux';
-import { RouterProvider, createBrowserRouter } from 'react-router-dom';
-import { RootRouter } from './routers/RootRouter';
-import { PdbRouter } from './routers/PdbRouter';
-import { TutorialRouter } from './routers/TutorialRouter';
-import { LigandRouter } from './routers/LigandRouter';
-import { GalleryRouter } from './routers/GalleryRouter';
-import { GallerySessionRouter } from './routers/GallerySessionRouter';
+import { Outlet, RouterProvider, createBrowserRouter } from 'react-router-dom';
+import { RootLayout } from './layouts/RootLayout';
+import { PdbLayout } from './layouts/PdbLayout';
+import { TutorialLayout } from './layouts/TutorialLayout';
+import { LigandLayout } from './layouts/LigandLayout';
+import { GalleryLayout } from './layouts/GalleryLayout';
+import { GallerySessionLayout } from './layouts/GallerySessionLayout';
 import React from 'react'
 
 export const MoorhenApp: React.FC = () => {
@@ -16,35 +16,35 @@ export const MoorhenApp: React.FC = () => {
         [
             {
                 path: "",
-                element: <RootRouter />,
+                element: <RootLayout />,
             },
             {
                 path: "/",
-                element: <RootRouter />,
+                element: <RootLayout />,
             },
             {
                 path: "/pdb/:pdbId",
-                element: <PdbRouter />,
+                element: <PdbLayout />,
             },
             {
                 path: "/:pdbId",
-                element: <PdbRouter />,
+                element: <PdbLayout />,
             },
             {
                 path: "/tutorial/:tutorialNumber",
-                element: <TutorialRouter />,
+                element: <TutorialLayout />,
             },
             {
                 path: "/ligand/:ligandName",
-                element: <LigandRouter />,
+                element: <LigandLayout />,
             },
             {
                 path: "/lig/:ligandName",
-                element: <LigandRouter />,
+                element: <LigandLayout />,
             },
             {
                 path: "/monomer/:ligandName",
-                element: <LigandRouter />,
+                element: <LigandLayout />,
             },
             {
                 path: "gallery",
@@ -57,7 +57,7 @@ export const MoorhenApp: React.FC = () => {
                 children: [
                     {
                         path: ":galleryId",
-                        element: <GallerySessionRouter />
+                        element: <GallerySessionLayout />
                     }
                 ]
             },

--- a/src/components/MoorhenApp.tsx
+++ b/src/components/MoorhenApp.tsx
@@ -48,7 +48,12 @@ export const MoorhenApp: React.FC = () => {
             },
             {
                 path: "gallery",
-                element: <GalleryRouter />,
+                element: (
+                    <>
+                        <GalleryLayout />
+                        <Outlet/>
+                    </>
+                ),
                 children: [
                     {
                         path: ":galleryId",

--- a/src/components/layouts/GalleryLayout.tsx
+++ b/src/components/layouts/GalleryLayout.tsx
@@ -3,7 +3,7 @@ import { useCallback, useState } from "react";
 import { Box, IconButton, Typography, Modal } from "@mui/material";
 import { PlayCircleOutlined } from '@mui/icons-material';
 
-export const GalleryRouter: React.FC = () => {
+export const GalleryLayout: React.FC = () => {
 
     const [showModal, setShowModal] = useState<boolean>(false)
     const [imageIndex, setImageIndex] = useState<number>(0)

--- a/src/components/layouts/GalleryLayout.tsx
+++ b/src/components/layouts/GalleryLayout.tsx
@@ -53,7 +53,7 @@ export const GalleryLayout: React.FC = () => {
         <div style={{width: '99vw', overflowX: 'hidden', overflowY: 'auto'}}>
           <Gallery images={images} enableImageSelection={false} onClick={handleFigureClick}/>
         </div>
-        <Modal open={showModal} onClose={() => setShowModal(false)} aria-labelledby="modal-modal-title" aria-describedby="modal-modal-description" style={{backdropFilter: "blur(5px)"}}>
+        <Modal open={showModal} onClose={() => setShowModal(false)} aria-labelledby="modal-modal-title" aria-describedby="modal-modal-description" style={{color: 'black', backdropFilter: "blur(5px)"}}>
         <Box sx={{
             display: 'flex',
             justifyContent: 'center',

--- a/src/components/layouts/GallerySessionLayout.tsx
+++ b/src/components/layouts/GallerySessionLayout.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { useDispatch, useSelector, useStore } from 'react-redux';
 
-export const GallerySessionRouter: React.FC = () => {
+export const GallerySessionLayout: React.FC = () => {
     const dispatch = useDispatch()
 
     const store = useStore()

--- a/src/components/layouts/LigandLayout.tsx
+++ b/src/components/layouts/LigandLayout.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 
-export const LigandRouter: React.FC = () => {
+export const LigandLayout: React.FC = () => {
     const dispatch = useDispatch()
     const cootInitialized = useSelector((state: moorhen.State) => state.generalStates.cootInitialized)
     const defaultBondSmoothness = useSelector((state: moorhen.State) => state.sceneSettings.defaultBondSmoothness)

--- a/src/components/layouts/PdbLayout.tsx
+++ b/src/components/layouts/PdbLayout.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 
-export const PdbRouter: React.FC = () => {
+export const PdbLayout: React.FC = () => {
     const dispatch = useDispatch()
     const cootInitialized = useSelector((state: moorhen.State) => state.generalStates.cootInitialized)
     const defaultBondSmoothness = useSelector((state: moorhen.State) => state.sceneSettings.defaultBondSmoothness)

--- a/src/components/layouts/RootLayout.tsx
+++ b/src/components/layouts/RootLayout.tsx
@@ -3,7 +3,7 @@ import { webGL } from 'moorhen/types/mgWebGL';
 import { moorhen } from 'moorhen/types/moorhen';
 import { useRef } from 'react';
 
-export const RootRouter: React.FC = () => {
+export const RootLayout: React.FC = () => {
 
     const glRef = useRef<webGL.MGWebGL | null>(null)
     const commandCentre = useRef<moorhen.CommandCentre | null>(null)

--- a/src/components/layouts/TutorialLayout.tsx
+++ b/src/components/layouts/TutorialLayout.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 
-export const TutorialRouter: React.FC = () => {
+export const TutorialLayout: React.FC = () => {
     const dispatch = useDispatch()
     const cootInitialized = useSelector((state: moorhen.State) => state.generalStates.cootInitialized)
     const defaultBondSmoothness = useSelector((state: moorhen.State) => state.sceneSettings.defaultBondSmoothness)

--- a/src/components/routers/TutorialRouter.tsx
+++ b/src/components/routers/TutorialRouter.tsx
@@ -47,7 +47,7 @@ export const TutorialRouter: React.FC = () => {
         await newDiffMap.loadToCootFromMtzURL(
             `${baseUrl}/moorhen-tutorial-map-number-${tutorialNumber}.mtz`,
             `diff-map-${tutorialNumber}`,
-            { F: "DELFWT", PHI: "PHDELWT", isDifference: true, useWeight: false, calcStructFact: true, ...tutorialMtzColumnNames[tutorialNumber] }
+            { ...tutorialMtzColumnNames[tutorialNumber], F: "DELFWT", PHI: "PHDELWT", isDifference: true, useWeight: false, calcStructFact: true }
         )
         dispatch( addMolecule(newMolecule) )
         dispatch( addMapList([newMap, newDiffMap]) )


### PR DESCRIPTION
This update includes:
- A fix for the issue where loading tutorial data using react router layouts would result in the wrong column names being used for the diff. maps.
- A fix for the nested routes inside the gallery layout.
- A fix for the issue where the text in the gallery modals is rendered white.